### PR TITLE
fix: replace BrowserRouter with HashRouter

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { HashRouter as Router, Route, Switch } from 'react-router-dom';
 
 import { Home } from 'pages/Home';
 import { About } from 'pages/About';


### PR DESCRIPTION
#### What is the goal of this change?
Replace `BrowserRouter` with `HashRouter` to avoid 404 errors while reloading pages on the browser.

#### Is there any issue related?
Since `BrowserRouter` depends on the server-side to redirect it to the correct page (and we can't perform any kind of back-end configuration usind GitHub Pages) when the user reloads a route it returns a 404 error because that page doesn't exists.

We could solve it by building static pages too, but I've chose to use `HashRouter` because it's easier now.

#### How does the changes address the issue?
The `HashRouter` uses a hashbang (`#`) on the URL, so the page doesn't really exists, and all the client routing is done by our `index.html`.
