### PR TITLE
fix: update reset.css

### DIFF
--- a/src/assets/css/reset.css
+++ b/src/assets/css/reset.css
@@ -32,14 +32,17 @@ h6,
 p,
 ul,
 ol,
-li {
+li,
+button,
+input {
   margin: 0;
 }
 
 ul,
 ol,
 li,
-button {
+button,
+input {
   padding: 0;
 }
 

--- a/src/components/Footer/styled.js
+++ b/src/components/Footer/styled.js
@@ -7,16 +7,19 @@ import { colors, viewports } from 'assets/styled/tokens';
 export const StyledFooter = styled.footer`
   flex-basis: 100%;
   margin-top: auto;
-  padding-bottom: 1rem;
-  text-align: center;
+  padding-bottom: 2rem;
 
   ${StyledContainer} {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
     justify-content: flex-start;
-    padding-top: 1rem;
+    padding-top: 2rem;
     border-top: 1px solid ${colors.grey};
+  }
+
+  p {
+    text-align: right;
   }
 
   a {


### PR DESCRIPTION
#### What is the goal of this change?
Update `reset.css` to avoid default margins and paddings on form elements (i.e. Safari case)

#### Is there any issue related?
N/A

#### How does the changes address the issue?
N/A
